### PR TITLE
HDLC: fix DMA callback chain, shadow memory, status display

### DIFF
--- a/src/cpu/cpu_mms.c
+++ b/src/cpu/cpu_mms.c
@@ -690,6 +690,11 @@ bool checkPageProtection(uint VPN, uint pageTable, ulong pageTableEntry, bool Us
 // Check if address is in shadow memory
 bool IsAddressShadowMemory(uint addr, bool privileged)
 {
+    // Shadow memory (page tables) only exists in the first 64K word address space.
+    // Physical addresses above 0xFFFF (bank > 0) can never be shadow memory.
+    if (addr > 0xFFFF)
+        return false;
+
     ushort pcr = gReg->reg_PCR[CurrLEVEL];
     unsigned char ring = pcr & 0x03;
     bool mms2Enabled = ((pcr & 1 << 2) != 0); // Is MMS-2 with 16-page-tables enabled on this PCR level ?
@@ -697,7 +702,7 @@ bool IsAddressShadowMemory(uint addr, bool privileged)
 
     if ((ring == 3) || (!STS_PONI) || privileged)
     {
-        
+
         if (STS_SEXI)
         {
             if ((mmsType == MMS2) && mms2Enabled)
@@ -761,6 +766,14 @@ void WriteVirtualMemory(uint virtualAddress, ushort value, bool UseAPT, WriteMod
 		disasm_set_isdata(virtualAddress);
 
     int pa = mapVirtualToPhysical(virtualAddress, WRITE, UseAPT);
+    /* TRACE: detect writes to VA 0x2F9D (_ov_saved_l_bss) */
+    if (virtualAddress == 0x2F9D) {
+        static int vw = 0;
+        if (vw < 5)
+            printf("\r\n*** VA_WRITE 0x2F9D val=0%06o pa=%d apt=%d PIL=%d PC=%06o\r\n",
+                   value, pa, UseAPT, CurrLEVEL, gPC);
+        vw++;
+    }
     if (pa == -1) return;
     WritePhysicalMemoryWM(pa, value, false,wm);
 }
@@ -841,6 +854,10 @@ void WritePhysicalMemoryWM(int physicalAddress, uint16_t value, bool privileged,
         }
         return;
     }
+
+    // Trace writes to _ov_saved_l_bss physical address
+    extern void check_phys_write(int pa, unsigned short value);
+    check_phys_write(physicalAddress, value);
 
     // Check memory bounds
     if ((physicalAddress >= ND_Memsize)||(physicalAddress < 0))
@@ -949,3 +966,13 @@ int Dbg_WritePhysicalMemory(uint32_t physicalAddress, uint16_t value)
 }
 
 // Check if privileged instruction execution is allowed
+
+/* TEMPORARY: trace writes to physical 0x2F9D (_ov_saved_l_bss) */
+static int trace_2f9d = 0;
+void check_phys_write(int pa, unsigned short value) {
+    if (pa == 0x2F9D && trace_2f9d < 10) {
+        printf("\r\n*** WRITE phys 0x2F9D = 0%06o PIL=%d PC=%06o\r\n",
+               value, gPIL, gPC);
+        trace_2f9d++;
+    }
+}

--- a/src/cpu/cpu_protos.h
+++ b/src/cpu/cpu_protos.h
@@ -1,6 +1,6 @@
 /* AUTO-GENERATED FILE. DO NOT EDIT! */
 
-/* E:/Dev/Emulators/ND/nd100x/src/cpu/cpu.c */
+/* /home/ronny/repos/nd100x/src/cpu/cpu.c */
 void do_op(ushort operand, bool isEXR);
 ushort New_GetEffectiveAddr(ushort instr, bool *use_apt);
 ushort calcIIC(void);
@@ -16,6 +16,7 @@ ushort MemoryFetch(ushort addr, bool UseAPT);
 bool checkAndSwitch(void);
 void private_cpu_tick(void);
 bool cpu_instruction_is_jump(void);
+void ring_dump(void);
 int cpu_run(int ticks);
 void cpu_init(bool debuggerEnabled, int debuggerPort);
 void init_cpu_debugger(void);
@@ -30,7 +31,7 @@ CpuStopReason get_cpu_stop_reason(void);
 void set_cpu_run_mode(CPURunMode new_mode);
 CPURunMode get_cpu_run_mode(void);
 
-/* E:/Dev/Emulators/ND/nd100x/src/cpu/cpu_instr.c */
+/* /home/ronny/repos/nd100x/src/cpu/cpu_instr.c */
 bool CheckPriv(void);
 short signExtend(ushort x);
 ushort do_add(ushort a, ushort b, ushort k);
@@ -165,12 +166,12 @@ void print_mask_binary(unsigned short mask);
 void Instruction_Add_Mask(int opcode, int mask, void *funcpointer);
 void Setup_Instructions(void);
 
-/* E:/Dev/Emulators/ND/nd100x/src/cpu/cpu_mopc.c */
+/* /home/ronny/repos/nd100x/src/cpu/cpu_mopc.c */
 int aoct2int(char *str);
 void mopc_cmd(char *cmdstr, char cmdc);
 void mopc_thread(void);
 
-/* E:/Dev/Emulators/ND/nd100x/src/cpu/cpu_disasm.c */
+/* /home/ronny/repos/nd100x/src/cpu/cpu_disasm.c */
 void OpToStr(char *return_string, uint16_t max_len, uint16_t operand);
 void disasm_allocate(ushort addr);
 void disasm_instr(ushort addr, ushort instr);
@@ -186,10 +187,6 @@ ushort decode_140k(ushort instr);
 ushort decode_150k(ushort instr);
 
 /* /home/ronny/repos/nd100x/src/cpu/float.c */
-long double pow2l(int i);
-int MUL32(unsigned long int *a, unsigned long int *b, unsigned long int *r);
-int old_NDFloat_Div(unsigned short int *p_a, unsigned short int *p_b, unsigned short int *p_r);
-int old_NDFloat_Mul(unsigned short int *p_a, unsigned short int *p_b, unsigned short int *p_r);
 int NDFloat_Add(ushort *p_a, ushort *p_b, ushort *p_r);
 int NDFloat_Sub(ushort *p_a, ushort *p_b, ushort *p_r);
 int NDFloat_Mul(ushort *p_a, ushort *p_b, ushort *p_r);
@@ -217,7 +214,7 @@ void setbit_STS_MSB(ushort stsbit, char val);
 void setbit(ushort regnum, ushort stsbit, char val);
 void AdjustSTS(ushort reg_a, ushort operand, int result);
 
-/* E:/Dev/Emulators/ND/nd100x/src/cpu/cpu_mms.c */
+/* /home/ronny/repos/nd100x/src/cpu/cpu_mms.c */
 bool CreatePagingTables(void);
 void DestroyPagingTables(void);
 ushort GetPTShadowAddress(uint pageTable, uint VPN, PageTableMode ptm);
@@ -245,8 +242,9 @@ void HandleMPV(uint virtualAddress);
 void HandlePF(uint virtualAddress);
 int Dbg_ReadPhysicalMemory(uint32_t physicalAddress);
 int Dbg_WritePhysicalMemory(uint32_t physicalAddress, uint16_t value);
+void check_phys_write(int pa, unsigned short value);
 
-/* E:/Dev/Emulators/ND/nd100x/src/cpu/cpu_bkpt.c */
+/* /home/ronny/repos/nd100x/src/cpu/cpu_bkpt.c */
 void breakpoint_manager_init(void);
 void breakpoint_manager_cleanup(void);
 void breakpoint_manager_step_one(void);
@@ -271,6 +269,6 @@ void phys_watchpoint_clear(void);
 int phys_watchpoint_get_count(void);
 int phys_watchpoint_get(int index, uint32_t *out_addr, int *out_type);
 
-/* E:/Dev/Emulators/ND/nd100x/src/cpu/expr_eval.c */
+/* /home/ronny/repos/nd100x/src/cpu/expr_eval.c */
 uint16_t expr_eval_value(const char *expr, const char **error);
 bool expr_eval_condition(const char *expr, const char **error);

--- a/src/devices/device.c
+++ b/src/devices/device.c
@@ -27,6 +27,7 @@
 
 #include "devices_types.h"
 #include "devices_protos.h"
+#include "../cpu/cpu_types.h"
 
 #define INITIAL_IO_DELAY_CAPACITY 16
 
@@ -361,13 +362,20 @@ int32_t Device_IO_BufferWriteWord(Device *dev,uint8_t *buf, int32_t word_offset,
     return 0;
 }
 
+// DMA accesses physical memory directly on the bus — no MMU, no shadow memory.
+// This matches the C# architecture where DMA goes through SystemBus.ReadMemory16()
+// which is a direct array access, completely separate from the CPU's MMS path.
 void Device_DMAWrite(uint32_t coreAddress, uint16_t data) {
-    WritePhysicalMemory(coreAddress & 0xFFFFFF, data, false);
+    uint32_t addr = coreAddress & 0xFFFFFF;
+    if (addr >= ND_Memsize) return;
+    VolatileMemory.n_Array[addr] = data;
 }
 
 int32_t Device_DMARead(uint32_t coreAddress)
 {
-    return ReadPhysicalMemory(coreAddress & 0xFFFFFF, false);
+    uint32_t addr = coreAddress & 0xFFFFFF;
+    if (addr >= ND_Memsize) return 0;
+    return (int32_t)VolatileMemory.n_Array[addr];
 }
 
 // Character Device Functions

--- a/src/devices/devices_protos.h
+++ b/src/devices/devices_protos.h
@@ -112,6 +112,7 @@ void COM5025_ClockTransmitter(COM5025State *chip);
 void COM5025_ProcessBit(COM5025State *chip, bool bit);
 void COM5025_ReceiveData(COM5025State *chip, const uint8_t *data, int length);
 void COM5025_TransmitData(COM5025State *chip, uint8_t data);
+void COM5025_SetReceiverStatus(COM5025State *chip, uint16_t newRxStatus);
 void COM5025_SetTransmitterOutputCallback(COM5025State *chip, void (*callback )(void *context, uint8_t data ), void *context);
 void COM5025_SetPinValueChangedCallback(COM5025State *chip, void (*callback )(void *context, COM5025SignalPinOut pin, bool value ), void *context);
 

--- a/src/devices/hdlc/chipCOM5025.c
+++ b/src/devices/hdlc/chipCOM5025.c
@@ -40,8 +40,6 @@ static void COM5025_TransmitByteOutput(COM5025State *chip, uint8_t data, bool is
 static void COM5025_SendOneByte(COM5025State *chip, uint8_t data);
 static bool COM5025_TSR_Empty(COM5025State *chip);
 static uint8_t COM5025_MapBits2CharLen(uint8_t bits);
-static void COM5025_SetReceiverStatus(COM5025State *chip, uint16_t newRxStatus);
-
 // Global state for the chip (could be per-device instance)
 static COM5025Registers registers;
 
@@ -598,7 +596,7 @@ static uint8_t COM5025_MapBits2CharLen(uint8_t bits)
         return bits;
 }
 
-static void COM5025_SetReceiverStatus(COM5025State *chip, uint16_t newRxStatus)
+void COM5025_SetReceiverStatus(COM5025State *chip, uint16_t newRxStatus)
 {
     if (!chip) return;
 

--- a/src/devices/hdlc/chipCOM5025.h
+++ b/src/devices/hdlc/chipCOM5025.h
@@ -293,6 +293,8 @@ void COM5025_ReceiveData(COM5025State *chip, const uint8_t *data, int length);
 void COM5025_TransmitData(COM5025State *chip, uint8_t data);
 
 // Callback setup functions
+void COM5025_SetReceiverStatus(COM5025State *chip, uint16_t newRxStatus);
+
 void COM5025_SetTransmitterOutputCallback(COM5025State *chip, void (*callback)(void *context, uint8_t data), void *context);
 void COM5025_SetPinValueChangedCallback(COM5025State *chip, void (*callback)(void *context, COM5025SignalPinOut pin, bool value), void *context);
 

--- a/src/devices/hdlc/deviceHDLC.c
+++ b/src/devices/hdlc/deviceHDLC.c
@@ -147,7 +147,6 @@ static void HDLC_CheckTriggerIRQ12(Device *self);
 static void HDLC_CheckTriggerIRQ13(Device *self);
 static void HDLC_CheckTriggerInterrupt(Device *self);
 static void HDLC_UpdateRQTS(Device *self);
-static void HDLC_UpdateFromCOM5025Pins(Device *self);
 
 // Modem event callbacks
 static void HDLC_OnModemReceivedData(Device *device, const uint8_t *data, int length);
@@ -209,6 +208,7 @@ static void HDLC_Reset(Device *self)
 
     // Reset DMA state
     data->dmaAddress = 0;
+    data->dmaBankBits = 0;
     data->dmaCommand = 0;
     data->txState = HDLC_DMA_TX_STOPPED;
     data->blockState = HDLC_DMA_BLOCK_IDLE;
@@ -306,12 +306,14 @@ static uint16_t HDLC_Read(Device *self, uint32_t address)
 
             value = data->rxTransferStatus.raw;
 
-            // Clear DMA bits 8-15 after read
+            // Clear DMA bits 8-14 after read (bit 15 receiverOverrun is NOT auto-cleared)
             data->rxTransferStatus.bits.blockEnd = 0;
             data->rxTransferStatus.bits.frameEnd = 0;
             data->rxTransferStatus.bits.listEnd = 0;
             data->rxTransferStatus.bits.listEmpty = 0;
             data->rxTransferStatus.bits.undefined12 = 0;
+            data->rxTransferStatus.bits.x21d = 0;
+            data->rxTransferStatus.bits.x21s = 0;
             break;
 
         case HDLC_READ_TX_TRANSFER_STATUS:     // IOX +12: Read Transmitter Transfer Status
@@ -446,23 +448,29 @@ static void HDLC_Write(Device *self, uint32_t address, uint16_t value)
 
         case HDLC_WRITE_DMA_ADDRESS:           // IOX +15: Write DMA Address
             data->dmaAddress = value;
-            // Update DMA engine with the new address
-            if (data->dmaEngine) {
-                DMAEngine_SetDMAAddress(data->dmaEngine, value);
-            }
+            // Address is stored locally; combined with bank bits when IOX+17 command is written
             break;
 
         case HDLC_WRITE_DMA_COMMAND:           // IOX +17: Write DMA Command
             data->dmaCommand = (value >> 8) & 0x07;
+            data->dmaBankBits = (uint8_t)(value & 0x0F);
 #ifdef HDLC_DEBUG
-            HDLC_LOG("DMA Command: %d (%s)", data->dmaCommand,
-                     data->dmaCommand < 8 ? hdlc_dma_cmd_name[data->dmaCommand] : "?");
+            {
+                static const char *cmd_names[] = {
+                    "DEVICE_CLEAR", "INITIALIZE", "RX_START", "RX_CONTINUE",
+                    "TX_START", "DUMP_DATA", "DUMP_REGS", "LOAD_REGS"
+                };
+                uint32_t fullAddr = ((uint32_t)data->dmaBankBits << 16) | data->dmaAddress;
+                HDLC_LOG("DMA %s addr=0x%05X (bank=%d lo=0x%04X)",
+                         cmd_names[data->dmaCommand & 7],
+                         fullAddr, data->dmaBankBits, data->dmaAddress);
+            }
 #endif
             // Execute DMA command
             if (data->dmaEngine) {
-                // First set the DMA address if it was provided
-                // Note: DMA address should be set via HDLC_WRITE_DMA_ADDRESS before command
-                // For data transfer commands, we need to pass the address to the DMA engine
+                // Combine bank bits with 16-bit DMA address to form 20-bit physical address
+                uint32_t fullDMAAddress = ((uint32_t)data->dmaBankBits << 16) | data->dmaAddress;
+                DMAEngine_SetDMAAddress(data->dmaEngine, fullDMAAddress);
 
                 switch (data->dmaCommand) {
                     case DMA_CMD_DEVICE_CLEAR:
@@ -788,7 +796,6 @@ static void HDLC_OnDMAWriteDMA(Device *device, uint32_t address, uint16_t data)
 {
     if (!device) return;
 
-    // Equivalent to C# DmaEngine_OnWriteDMA
     Device_DMAWrite(address, data);
 }
 
@@ -851,12 +858,13 @@ static void HDLC_OnCOM5025TransmitterOutput(Device *device, uint8_t serialOutput
 {
     if (!device) return;
 
-    HDLCData *data = (HDLCData *)device->deviceData;
-    if (!data || !data->modem) return;
-
-    // Equivalent to C# Com5025_OnTransmitterOutput
-    // Send serial output byte to modem
-    Modem_SendByte(data->modem, serialOutput);
+    // In burst mode (always active), the DMA engine handles all transmission
+    // via Modem_SendBytes. The COM5025 character-mode output must NOT be sent
+    // to the modem, as it would mix idle flags (0x7E) into the TCP stream
+    // and corrupt the byte-stuffed HDLC frames.
+    //
+    // This callback is only needed for character mode (non-DMA), which is not used.
+    (void)serialOutput;
 }
 
 // COM5025 pin value changed callback implementation
@@ -938,37 +946,6 @@ static void HDLC_OnCOM5025PinValueChanged(Device *device, COM5025SignalPinOut pi
 
     // Check and trigger interrupts based on pin changes
     HDLC_CheckTriggerInterrupt(device);
-}
-
-// Helper functions for future implementation
-
-static void HDLC_CheckInterrupts(Device *self)
-{
-    if (!self) return;
-
-    HDLCData *data = (HDLCData *)self->deviceData;
-
-    // Check level 13 (receiver) interrupts
-    if (data->rxTransferStatus.bits.dataAvailable &&
-        data->rxTransferControl.bits.dataAvailableIE) {
-        Device_SetInterruptStatus(self, true, 13);
-    }
-
-    if (data->rxTransferStatus.bits.statusAvailable &&
-        data->rxTransferControl.bits.statusAvailableIE) {
-        Device_SetInterruptStatus(self, true, 13);
-    }
-
-    // Check level 12 (transmitter) interrupts
-    if (data->txTransferStatus.bits.transmitBufferEmpty &&
-        data->txTransferControl.bits.transmitBufferEmptyIE) {
-        Device_SetInterruptStatus(self, true, 12);
-    }
-
-    if (data->txTransferStatus.bits.transmitterUnderrun &&
-        data->txTransferControl.bits.transmitterUnderrunIE) {
-        Device_SetInterruptStatus(self, true, 12);
-    }
 }
 
 static void HDLC_CheckTriggerIRQ12(Device *self)
@@ -1084,85 +1061,6 @@ static void HDLC_UpdateRQTS(Device *self)
     }
 }
 
-static void HDLC_UpdateFromCOM5025Pins(Device *self)
-{
-    if (!self) return;
-
-    HDLCData *data = (HDLCData *)self->deviceData;
-    if (!data || !data->com5025) return;
-
-    bool needsInterruptCheck = false;
-    bool needsRQTSUpdate = false;
-
-    // Check SFR pin - Sync/Flag received (bit 3)
-    bool sfr = COM5025_GetOutputPin(data->com5025, COM5025_PIN_OUT_SFR);
-    if (sfr != data->rxTransferStatus.bits.syncFlagReceived) {
-        data->rxTransferStatus.bits.syncFlagReceived = sfr;
-    }
-
-    // Check RXACT pin - Receiver Active (bit 2)
-    bool rxact = COM5025_GetOutputPin(data->com5025, COM5025_PIN_OUT_RXACT);
-    if (rxact != data->rxTransferStatus.bits.receiverActive) {
-        data->rxTransferStatus.bits.receiverActive = rxact;
-    }
-
-    // Check RDA pin - Receiver Data Available (interrupt on level 13 if enabled)
-    bool rda = COM5025_GetOutputPin(data->com5025, COM5025_PIN_OUT_RDA);
-    if (rda != data->rxTransferStatus.bits.dataAvailable) {
-        data->rxTransferStatus.bits.dataAvailable = rda;
-        if (rda) {
-            needsInterruptCheck = true;
-        }
-    }
-
-    // Check RSA pin - Receiver STATUS available (bit 1)
-    bool rsa = COM5025_GetOutputPin(data->com5025, COM5025_PIN_OUT_RSA);
-    if (rsa != data->rxTransferStatus.bits.statusAvailable) {
-        data->rxTransferStatus.bits.statusAvailable = rsa;
-        if (rsa) {
-            needsInterruptCheck = true;
-        }
-    }
-
-    // Check TXACT pin - Transmitter Active (bit 2)
-    bool txact = COM5025_GetOutputPin(data->com5025, COM5025_PIN_OUT_TXACT);
-    if (txact != data->txTransferStatus.bits.transmitterActive) {
-        data->txTransferStatus.bits.transmitterActive = txact;
-        needsRQTSUpdate = true; // TXACT may impact RQTS
-    }
-
-    // Check TBMT pin - Transmitter Buffer Empty (interrupt on level 12 if enabled)
-    bool tbmt = COM5025_GetOutputPin(data->com5025, COM5025_PIN_OUT_TBMT);
-    if (tbmt != data->txTransferStatus.bits.transmitBufferEmpty) {
-        data->txTransferStatus.bits.transmitBufferEmpty = tbmt;
-        if (tbmt) {
-            needsInterruptCheck = true;
-        }
-    }
-
-    // Check TSA pin - Transmitter Status Available (TERR bit, indicating transmitter underflow)
-    bool tsa = COM5025_GetOutputPin(data->com5025, COM5025_PIN_OUT_TSA);
-    if (tsa != data->txTransferStatus.bits.transmitterUnderrun) {
-        data->txTransferStatus.bits.transmitterUnderrun = tsa;
-        if (tsa) {
-            needsInterruptCheck = true;
-        }
-    }
-
-    // Update RQTS if transmitter active state changed
-    if (needsRQTSUpdate) {
-        HDLC_UpdateRQTS(self);
-    }
-
-    // Check for interrupt triggers if any pin changed that affects interrupts
-    if (needsInterruptCheck) {
-        HDLC_CheckTriggerInterrupt(self);
-    }
-
-    // In burst mode, TX is handled by DMATransmitter_Tick/SendAllBuffers
-    // COM5025 character-mode SendChar is not used
-}
-
 static void HDLC_SetBaudRate(Device *self, HDLCBaudRate baudRate)
 {
     if (!self) return;
@@ -1218,9 +1116,11 @@ bool HDLC_GetRxFrameStatus(const HDLCData *data, HDLCRxFrameStatus *status)
 
     if (!data->dmaEngine || !data->dmaEngine->dmaCB) return false;
 
-    status->rxDmaEnabled = data->rxTransferControl.bits.enableReceiverDMA;
-
     DMAControlBlocks *cb = (DMAControlBlocks *)data->dmaEngine->dmaCB;
+
+    // RX status
+    status->rxDmaEnabled = data->rxTransferControl.bits.enableReceiverDMA;
+    status->rxEnabled = data->rxTransferControl.bits.enableReceiver;
     HDLCFrame *rxFrame = cb->hdlcReceiveFrame;
     if (rxFrame) {
         status->state = (int)rxFrame->state;
@@ -1228,12 +1128,26 @@ bool HDLC_GetRxFrameStatus(const HDLCData *data, HDLCRxFrameStatus *status)
     }
     status->rxDcbReady = (cb->rxDCB != NULL);
 
-    // Cast needed: dmaEngine.h uses opaque 'struct DMAReceiver *' but
-    // dmaReceiver.h defines 'typedef struct { ... } DMAReceiver' (anonymous).
     DMAReceiver *rx = (DMAReceiver *)data->dmaEngine->receiver;
     if (rx) {
         status->tcpQueueUsed = TcpReceiveBuffer_Available(&rx->tcpReceiveBuffer);
     }
+
+    // TX status
+    status->txDmaEnabled = data->txTransferControl.bits.enableTransmitterDMA;
+    status->txEnabled = data->txTransferControl.bits.transmitterEnabled;
+    status->txSenderState = cb->dmaSenderState;
+    status->txWaitTicks = cb->dmaWaitTicks;
+
+#ifdef MODEM_HAS_NETWORKING
+    if (data->modem) {
+        pthread_mutex_lock(&((ModemState *)data->modem)->txQueue.mtx);
+        int h = data->modem->txQueue.head;
+        int t = data->modem->txQueue.tail;
+        status->txQueueUsed = (h - t + MODEM_QUEUE_SIZE) % MODEM_QUEUE_SIZE;
+        pthread_mutex_unlock(&((ModemState *)data->modem)->txQueue.mtx);
+    }
+#endif
 
     return true;
 }

--- a/src/devices/hdlc/deviceHDLC.h
+++ b/src/devices/hdlc/deviceHDLC.h
@@ -247,6 +247,7 @@ typedef struct {
 
     // DMA state
     uint16_t dmaAddress;
+    uint8_t dmaBankBits;        // 4 bits for bank select (bits 16-19 of physical address)
     uint8_t dmaCommand;
     HDLCDMATxState txState;
     HDLCDMABlockState blockState;
@@ -289,13 +290,22 @@ typedef struct {
     uint64_t framesRxErrors;
 } HDLCData;
 
-// RX frame status for external inspection (menu, debugging)
+// HDLC status for external inspection (menu, debugging)
 typedef struct {
+    // RX status
     int state;          // HDLCReceiveState: 0=IDLE, 1=RECEIVING, 2=ESCAPE, 3=ERROR
     int frameLength;    // bytes accumulated in current frame
     int tcpQueueUsed;   // bytes waiting in TCP receive buffer
     bool rxDmaEnabled;  // receiver DMA enabled by SINTRAN
+    bool rxEnabled;     // receiver enabled (RXE bit)
     bool rxDcbReady;    // RX DMA control block available
+
+    // TX status
+    bool txDmaEnabled;  // transmitter DMA enabled by SINTRAN
+    bool txEnabled;     // transmitter enabled (TXE bit)
+    int txSenderState;  // DmaEngineSenderState: 0=STOPPED, 1=READY, 2=SENDING, 3=SENT
+    int txWaitTicks;    // dmaWaitTicks countdown (-1 = disabled)
+    int txQueueUsed;    // bytes waiting in modem TX queue
 } HDLCRxFrameStatus;
 
 // Function declarations

--- a/src/devices/hdlc/dmaControlBlocks.c
+++ b/src/devices/hdlc/dmaControlBlocks.c
@@ -55,9 +55,9 @@ void DMAControlBlocks_Init(DMAControlBlocks *dcbs, struct Device *hdlcDevice)
     dcbs->hdlcDevice = hdlcDevice;
 
     // Initialize outbound buffer
+    dcbs->outboundBufferCapacity = HDLC_MAX_FRAME_SIZE + 64;
+    dcbs->outboundBuffer = malloc(dcbs->outboundBufferCapacity);
     dcbs->outboundBufferSize = 0;
-    dcbs->outboundBufferCapacity = 0;
-    dcbs->outboundBuffer = NULL;
 
     // Initialize DCBs
     dcbs->txDCB = NULL;
@@ -159,6 +159,7 @@ void DMAControlBlocks_SetTXPointer(DMAControlBlocks *dmaCB, uint32_t listPointer
 
 void DMAControlBlocks_DebugTXFrames(DMAControlBlocks *dmaCB)
 {
+#ifdef DMA_DEBUG
     if (!dmaCB) return;
 
     for (int i = 0; i < 100; i++) {
@@ -166,7 +167,6 @@ void DMAControlBlocks_DebugTXFrames(DMAControlBlocks *dmaCB)
 
         uint16_t keyValue = (uint16_t)DMAControlBlocks_DMARead(dmaCB, addr);
         KeyFlags key = (KeyFlags)(keyValue & 0xFF00);
-        KeyFlags keySmall = (KeyFlags)(keyValue & 0x00FF);
 
         DMAControlBlocks_Log(dmaCB, "TXAnalyse: Offset=%d LP=0x%06X Key=0x%04X", i, addr, keyValue);
 
@@ -175,6 +175,9 @@ void DMAControlBlocks_DebugTXFrames(DMAControlBlocks *dmaCB)
             return;
         }
     }
+#else
+    (void)dmaCB;
+#endif
 }
 
 void DMAControlBlocks_LoadTXBuffer(DMAControlBlocks *dmaCB)
@@ -206,7 +209,9 @@ void DMAControlBlocks_MarkBufferSent(DMAControlBlocks *dmaCB)
         uint16_t data = (uint16_t)(DCB_GetDataFlowCost(dmaCB->txDCB) | (uint16_t)(KEYFLAG_ALREADY_TRANSMITTED_BLOCK));
         DCB_SetKeyValue(dmaCB->txDCB, data);
 
+#ifdef DMA_DEBUG
         DMAControlBlocks_Log(dmaCB, "MarkBufferSent: Status Word = 0x%04X", data);
+#endif
         DMAControlBlocks_DMAWrite(dmaCB, DCB_GetBufferAddress(dmaCB->txDCB), data);
     }
 }
@@ -501,6 +506,7 @@ void DMAControlBlocks_WriteNextByteDMA(DMAControlBlocks *dmaCB, uint8_t data, bo
     }
 
     if (!description) return;
+
 
     int bytesWritten = DCB_GetDMABytesWritten(description);
     uint16_t displacement = DCB_GetDisplacement(description);

--- a/src/devices/hdlc/dmaEngine.c
+++ b/src/devices/hdlc/dmaEngine.c
@@ -40,11 +40,51 @@
 #include "../devices_types.h"
 
 // Debug flags (convert from C# #define)
-#define DEBUG_DETAIL
-#define DEBUG_DETAIL_PLUS_DESCRIPTION
+// #define DEBUG_DETAIL
+// #define DEBUG_DETAIL_PLUS_DESCRIPTION
 // #define DMA_DEBUG
 
-// Remove static declaration since it's declared public in header
+// ---------------------------------------------------------------------------
+// Forwarding wrappers: bridge DMAControlBlocks/TX/RX callbacks to DMAEngine
+// ---------------------------------------------------------------------------
+
+// DMAControlBlocks read callback: context is DMAEngine*, forward to DMAEngine_DMARead
+static uint16_t DMAEngine_CBReadDMA(void *context, uint32_t address)
+{
+    DMAEngine *dma = (DMAEngine *)context;
+    int result = DMAEngine_DMARead(dma, address);
+    return (result >= 0) ? (uint16_t)result : 0;
+}
+
+// DMAControlBlocks write callback: context is DMAEngine*, forward to DMAEngine_DMAWrite
+static void DMAEngine_CBWriteDMA(void *context, uint32_t address, uint16_t data)
+{
+    DMAEngine *dma = (DMAEngine *)context;
+    DMAEngine_DMAWrite(dma, address, data);
+}
+
+// DMATransmitter send frame callback: context is DMAEngine*, forward to onSendHDLCFrame
+static void DMAEngine_TXSendFrame(void *context, HDLCFrame *frame)
+{
+    DMAEngine *dma = (DMAEngine *)context;
+    if (dma && dma->onSendHDLCFrame) {
+        dma->onSendHDLCFrame(dma->hdlcDevice, frame);
+    }
+}
+
+// DMATransmitter interrupt callback: context is DMAEngine*, forward to onSetInterruptBit
+static void DMAEngine_TXInterrupt(void *context, uint8_t bit)
+{
+    DMAEngine *dma = (DMAEngine *)context;
+    DMAEngine_OnSetInterruptBit(dma, bit);
+}
+
+// DMAReceiver interrupt callback: context is DMAEngine*, forward to onSetInterruptBit
+static void DMAEngine_RXInterrupt(void *context, uint8_t bit)
+{
+    DMAEngine *dma = (DMAEngine *)context;
+    DMAEngine_OnSetInterruptBit(dma, bit);
+}
 
 void DMAEngine_Init(DMAEngine *dma, bool burstMode, struct Device *hdlcDevice, void *modem, void *com5025)
 {
@@ -70,15 +110,17 @@ void DMAEngine_Init(DMAEngine *dma, bool burstMode, struct Device *hdlcDevice, v
 
     if (dma->transmitter) {
         DMATransmitter_Init(dma->transmitter, com5025, dma->dmaCB, hdlcDevice);
-        // Connect transmitter events
-        DMATransmitter_SetSendFrameCallback(dma->transmitter, NULL); // Will be set via callback
-        DMATransmitter_SetInterruptCallback(dma->transmitter, NULL); // Will be set via callback
+        // Wire transmitter callbacks through DMAEngine forwarding wrappers
+        DMATransmitter_SetSendFrameCallback(dma->transmitter, DMAEngine_TXSendFrame);
+        DMATransmitter_SetInterruptCallback(dma->transmitter, DMAEngine_TXInterrupt);
+        dma->transmitter->callbackContext = dma;
     }
 
     if (dma->receiver) {
         DMAReceiver_Init(dma->receiver, com5025, dma->dmaCB, hdlcDevice);
-        // Connect receiver events
-        DMAReceiver_SetInterruptCallback(dma->receiver, NULL); // Will be set via callback
+        // Wire receiver interrupt callback through DMAEngine forwarding wrapper
+        DMAReceiver_SetInterruptCallback(dma->receiver, DMAEngine_RXInterrupt);
+        dma->receiver->callbackContext = dma;
     }
 
     // Initialize state
@@ -91,10 +133,10 @@ void DMAEngine_Init(DMAEngine *dma, bool burstMode, struct Device *hdlcDevice, v
         ((DMAControlBlocks *)dma->dmaCB)->parameters = &dma->parameterBuffer;
     }
 
-    // Set up DMA control blocks callbacks
+    // Wire DMA control blocks memory access callbacks through DMAEngine forwarding wrappers
     if (dma->dmaCB) {
-        DMAControlBlocks_SetReadDMACallback(dma->dmaCB, NULL, dma);
-        DMAControlBlocks_SetWriteDMACallback(dma->dmaCB, NULL, dma);
+        DMAControlBlocks_SetReadDMACallback(dma->dmaCB, DMAEngine_CBReadDMA, dma);
+        DMAControlBlocks_SetWriteDMACallback(dma->dmaCB, DMAEngine_CBWriteDMA, dma);
     }
 
     // Initialize DMA registers array

--- a/src/devices/hdlc/dmaReceiver.c
+++ b/src/devices/hdlc/dmaReceiver.c
@@ -47,6 +47,7 @@ void DMAReceiver_Init(DMAReceiver *receiver, void *com5025, DMAControlBlocks *dm
     receiver->bytesReceived = 0;
     receiver->processTcpBufDelay = 0;
     receiver->onSetInterruptBit = NULL;
+    receiver->callbackContext = NULL;
 
     TcpReceiveBuffer_Init(&receiver->tcpReceiveBuffer, TCP_RECV_BUF_DEFAULT_CAPACITY);
 }
@@ -68,8 +69,9 @@ void DMAReceiver_Clear(DMAReceiver *receiver)
 
 // ---------------------------------------------------------------------------
 // Tick: called every CPU cycle from DMAEngine_Tick.
-// Processes ONE complete HDLC frame from the ring buffer per tick.
-// Rate-limited with processTcpBufDelay to give SINTRAN time to handle IRQs.
+// Processes ONE complete HDLC frame per call.
+// Adaptive delay: short delay (50 ticks) when queue is backing up,
+// normal delay (500 ticks) when queue is manageable.
 // ---------------------------------------------------------------------------
 void DMAReceiver_Tick(DMAReceiver *receiver)
 {
@@ -80,11 +82,18 @@ void DMAReceiver_Tick(DMAReceiver *receiver)
         return;
     }
 
-    if (TcpReceiveBuffer_Available(&receiver->tcpReceiveBuffer) > 0) {
+    int available = TcpReceiveBuffer_Available(&receiver->tcpReceiveBuffer);
+    if (available > 0) {
         DMAReceiver_ProcessBufferedData(receiver);
-        // Delay after processing - gives SINTRAN time to process IRQ
-        // and send RR with correct N(R)
-        receiver->processTcpBufDelay = 10000;
+
+        // Adaptive delay: process faster when queue has significant backlog
+        if (available > 32768) {
+            receiver->processTcpBufDelay = 50;   // >32KB queued: minimal delay
+        } else if (available > 8192) {
+            receiver->processTcpBufDelay = 200;  // >8KB queued: reduced delay
+        } else {
+            receiver->processTcpBufDelay = 500;  // Low queue: normal delay
+        }
     }
 }
 
@@ -129,13 +138,13 @@ int DMAReceiver_ProcessBufferedData(DMAReceiver *receiver)
     int bytesProcessed = 0;
 
     while (bytesProcessed < maxBytes) {
-        // Ensure we have a valid DMA buffer
-        if (receiver->dmaCB->rxDCB->keyValue != KEYFLAG_EMPTY_RECEIVER_BLOCK) {
+        // Ensure we have a valid DMA buffer (compare KEY bits 8-10 only, not RCOST low byte)
+        if (DCB_GetKey(receiver->dmaCB->rxDCB) != KEYFLAG_EMPTY_RECEIVER_BLOCK) {
             DMAControlBlocks_LoadNextRXBuffer(receiver->dmaCB);
         }
 
         if (!receiver->dmaCB->rxDCB ||
-            receiver->dmaCB->rxDCB->keyValue != KEYFLAG_EMPTY_RECEIVER_BLOCK) {
+            DCB_GetKey(receiver->dmaCB->rxDCB) != KEYFLAG_EMPTY_RECEIVER_BLOCK) {
             DMAReceiver_SetRXDMAFlag(receiver, RTS_RECEIVER_OVERRUN | RTS_LIST_EMPTY);
             return bytesProcessed;
         }
@@ -153,6 +162,8 @@ int DMAReceiver_ProcessBufferedData(DMAReceiver *receiver)
             if (!DMAControlBlocks_LoadNextRXBuffer(receiver->dmaCB)) {
                 DMAReceiver_SetRXDMAFlag(receiver, RTS_LIST_EMPTY);
             }
+            // Exit after one frame - give SINTRAN time to handle IRQ
+            // Next call will start fresh with new frame (matches C# behavior)
             return bytesProcessed;
         }
     }
@@ -208,7 +219,11 @@ bool DMAReceiver_ProcessCompleteFrame(DMAReceiver *receiver)
     }
 
     if (writeSuccess) {
-        COM5025_WriteByte(receiver->com5025, COM5025_REG_BYTE_RECEIVER_STATUS, 0x03);
+        // Set RSOM|REOM in COM5025 receiver status (triggers RSA pin → status available)
+        // Note: COM5025_WriteByte to receiver status is a no-op (read-only register).
+        // Must use SetReceiverStatus which updates status and triggers pin callbacks.
+        COM5025_SetReceiverStatus(receiver->com5025,
+            COM5025_RX_STATUS_RSOM | COM5025_RX_STATUS_REOM);
         DMAControlBlocks_MarkBufferReceived(receiver->dmaCB, 0x03);
 
         DMAReceiver_SetRXDMAFlag(receiver,
@@ -271,7 +286,7 @@ bool DMAReceiver_FindNextReceiveBuffer(DMAReceiver *receiver)
     if (!receiver || !receiver->dmaCB) return false;
 
     if (receiver->dmaCB->rxDCB &&
-        receiver->dmaCB->rxDCB->keyValue == KEYFLAG_EMPTY_RECEIVER_BLOCK) {
+        DCB_GetKey(receiver->dmaCB->rxDCB) == KEYFLAG_EMPTY_RECEIVER_BLOCK) {
         return true;
     }
 
@@ -289,10 +304,10 @@ DMAReceiveStatus DMAReceiver_ReceiveDataBufferByte(DMAReceiver *receiver, uint8_
     DMAControlBlocks *dmaCB = receiver->dmaCB;
     if (!dmaCB->rxDCB) return DMA_RECEIVE_NO_BUFFER;
 
-    int maxBlockLen = dmaCB->parameters ? dmaCB->parameters->maxReceiverBlockLength : 0;
+    int maxBlockLen = dmaCB->parameters ? dmaCB->parameters->maxReceiverBlockLength : 256;
 
-    // Check if buffer is full BEFORE writing
-    if (maxBlockLen > 0 && dmaCB->rxDCB->dmaBytesWritten >= maxBlockLen) {
+    // Check if buffer is full BEFORE writing (matches C#: dma_bytes_written >= MaxReceiverBlockLength)
+    if (dmaCB->rxDCB->dmaBytesWritten >= maxBlockLen) {
         // Mark with RSOM only (frame continues to next buffer)
         DMAControlBlocks_MarkBufferReceived(dmaCB, 0x01);
         DMAReceiver_SetRXDMAFlag(receiver,
@@ -302,7 +317,9 @@ DMAReceiveStatus DMAReceiver_ReceiveDataBufferByte(DMAReceiver *receiver, uint8_
         return DMA_RECEIVE_BUFFER_FULL;
     }
 
-    if (dmaCB->rxDCB->keyValue == KEYFLAG_EMPTY_RECEIVER_BLOCK) {
+    if (DCB_GetKey(dmaCB->rxDCB) == KEYFLAG_EMPTY_RECEIVER_BLOCK) {
+        // maxReceiverBlockLength == 0 means no limit (parameters may not include this)
+        // The C# version has no guard here — it writes unconditionally when key is EmptyReceiverBlock
         DMAControlBlocks_WriteNextByteDMA(dmaCB, data, true);
         receiver->bytesReceived++;
     }
@@ -323,10 +340,14 @@ void DMAReceiver_SetRXDMAFlag(DMAReceiver *receiver, uint16_t flag)
     // Always add SD and DSR flags (burst mode always active)
     flag |= RTS_SIGNAL_DETECTOR | RTS_DATA_SET_READY;
 
+    // LIST_EMPTY: stop receiver (clear ReceiverActive status bit)
+    // Note: do NOT clear enableReceiverDMA — that's SINTRAN's control register bit.
+    // SINTRAN will issue RECEIVER_CONTINUE to provide new buffers.
     if (flag & RTS_LIST_EMPTY) {
         hdlcData->rxTransferStatus.bits.receiverActive = 0;
     }
 
+    // Check if next buffer is available; if not, force LIST_EMPTY
     if (receiver->dmaCB && !DMAControlBlocks_IsNextRXbufValid(receiver->dmaCB)) {
         flag |= RTS_LIST_EMPTY;
     }
@@ -349,7 +370,7 @@ void DMAReceiver_SetRXDMAFlag(DMAReceiver *receiver, uint16_t flag)
     if (hdlcData->rxTransferControl.bits.dmaModuleIE &&
         hdlcData->rxTransferStatus.bits.dmaModuleRequest) {
         if (receiver->onSetInterruptBit) {
-            receiver->onSetInterruptBit(13);
+            receiver->onSetInterruptBit(receiver->callbackContext, 13);
         }
     }
 }

--- a/src/devices/hdlc/dmaReceiver.h
+++ b/src/devices/hdlc/dmaReceiver.h
@@ -33,8 +33,8 @@ struct Device;
 #include "dmaControlBlocks.h"
 #include "tcpReceiveBuffer.h"
 
-// DMA Receiver callback function types
-typedef void (*DMAReceiverSetInterruptCallback)(uint8_t bit);
+// DMA Receiver callback function types (with context for forwarding)
+typedef void (*DMAReceiverSetInterruptCallback)(void *context, uint8_t bit);
 
 // DMA Receiver status enumeration
 typedef enum {
@@ -60,8 +60,9 @@ typedef struct DMAReceiver {
     DMAControlBlocks *dmaCB;
     struct Device *hdlcDevice;
 
-    // Callbacks
+    // Callbacks (with context)
     DMAReceiverSetInterruptCallback onSetInterruptBit;
+    void *callbackContext;
 
 } DMAReceiver;
 

--- a/src/devices/hdlc/dmaTransmitter.c
+++ b/src/devices/hdlc/dmaTransmitter.c
@@ -49,6 +49,7 @@ void DMATransmitter_Init(DMATransmitter *transmitter, void *com5025, DMAControlB
     transmitter->bytesSent = 0;
     transmitter->onSendHDLCFrame = NULL;
     transmitter->onSetInterruptBit = NULL;
+    transmitter->callbackContext = NULL;
 }
 
 void DMATransmitter_Destroy(DMATransmitter *transmitter)
@@ -137,7 +138,7 @@ void DMATransmitter_SetTXDMAFlag(DMATransmitter *transmitter, uint16_t flag)
     if (hdlcData->txTransferControl.bits.dmaModuleIE &&
         hdlcData->txTransferStatus.bits.dmaModuleRequest) {
         if (transmitter->onSetInterruptBit) {
-            transmitter->onSetInterruptBit(12);
+            transmitter->onSetInterruptBit(transmitter->callbackContext, 12);
         }
     }
 }
@@ -160,15 +161,15 @@ bool DMATransmitter_SendAllBuffers(DMATransmitter *transmitter)
     while (true) {
         if (!dmaCB->txDCB) return true;
 
-        // Skip already transmitted blocks
+        // Skip already transmitted blocks (compare KEY bits 8-10 only, not RCOST low byte)
         while (dmaCB->txDCB &&
-               dmaCB->txDCB->keyValue == KEYFLAG_ALREADY_TRANSMITTED_BLOCK) {
+               DCB_GetKey(dmaCB->txDCB) == KEYFLAG_ALREADY_TRANSMITTED_BLOCK) {
             DMAControlBlocks_LoadNextTXBuffer(dmaCB);
         }
 
         if (!dmaCB->txDCB) return true;
 
-        if (dmaCB->txDCB->keyValue == KEYFLAG_BLOCK_TO_BE_TRANSMITTED) {
+        if (DCB_GetKey(dmaCB->txDCB) == KEYFLAG_BLOCK_TO_BE_TRANSMITTED) {
             // Start of new frame: clear outbound buffer
             if (DCB_HasRSOMFlag(dmaCB->txDCB)) {
                 dmaCB->outboundBufferSize = 0;
@@ -199,7 +200,7 @@ bool DMATransmitter_SendAllBuffers(DMATransmitter *transmitter)
                         memcpy(callbackFrame.frameBuffer, frameBuffer, (size_t)frameLength);
                         callbackFrame.frameLength = frameLength;
                         callbackFrame.frameComplete = true;
-                        transmitter->onSendHDLCFrame(&callbackFrame);
+                        transmitter->onSendHDLCFrame(transmitter->callbackContext, &callbackFrame);
                     }
                 }
                 dmaCB->outboundBufferSize = 0;

--- a/src/devices/hdlc/dmaTransmitter.h
+++ b/src/devices/hdlc/dmaTransmitter.h
@@ -32,9 +32,9 @@ struct Device;
 #include "dmaControlBlocks.h"
 #include "hdlcFrame.h"
 
-// DMA Transmitter callback function types
-typedef void (*DMATransmitterSendFrameCallback)(HDLCFrame *frame);
-typedef void (*DMATransmitterSetInterruptCallback)(uint8_t bit);
+// DMA Transmitter callback function types (with context for forwarding)
+typedef void (*DMATransmitterSendFrameCallback)(void *context, HDLCFrame *frame);
+typedef void (*DMATransmitterSetInterruptCallback)(void *context, uint8_t bit);
 
 // DMA Transmitter state structure
 typedef struct DMATransmitter {
@@ -46,9 +46,10 @@ typedef struct DMATransmitter {
     DMAControlBlocks *dmaCB;
     struct Device *hdlcDevice;
 
-    // Callbacks
+    // Callbacks (with context)
     DMATransmitterSendFrameCallback onSendHDLCFrame;
     DMATransmitterSetInterruptCallback onSetInterruptBit;
+    void *callbackContext;
 
 } DMATransmitter;
 

--- a/src/devices/hdlc/modem.h
+++ b/src/devices/hdlc/modem.h
@@ -38,7 +38,9 @@
 typedef struct Device Device;
 
 // Thread-safe byte queue for RX/TX between worker thread and emulation
-#define MODEM_QUEUE_SIZE 65536
+// Must be large enough to absorb TCP bursts without dropping bytes,
+// which would break HDLC frame boundaries and cause CRC errors.
+#define MODEM_QUEUE_SIZE (512 * 1024)
 
 #ifdef MODEM_HAS_NETWORKING
 typedef struct {
@@ -93,9 +95,11 @@ typedef struct ModemState {
     #endif
 #endif
 
-    // Traffic statistics (updated from emulation thread)
+    // Traffic statistics
     uint64_t bytesTx;
     uint64_t bytesRx;
+    uint64_t rxDropped;     // bytes dropped due to rxQueue overflow
+    uint64_t txDropped;     // bytes dropped due to txQueue overflow
 
     // Callbacks to HDLC device (called from emulation thread only)
     Device *hdlcDevice;

--- a/src/devices/hdlc/tcpReceiveBuffer.h
+++ b/src/devices/hdlc/tcpReceiveBuffer.h
@@ -26,8 +26,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-// Default capacity: 64KB for high-throughput HDLC
-#define TCP_RECV_BUF_DEFAULT_CAPACITY 65536
+// Default capacity: 2MB - must be large enough to absorb TX bursts
+// without dropping data while the emulation thread drains it
+#define TCP_RECV_BUF_DEFAULT_CAPACITY (2 * 1024 * 1024)
 
 typedef struct {
     uint8_t *buffer;

--- a/src/frontend/nd100x/nd100x_protos.h
+++ b/src/frontend/nd100x/nd100x_protos.h
@@ -1,11 +1,11 @@
 /* AUTO-GENERATED FILE. DO NOT EDIT! */
 
-/* E:/Dev/Emulators/ND/nd100x/src/frontend/nd100x/config.c */
+/* /home/ronny/repos/nd100x/src/frontend/nd100x/config.c */
 void Config_Init(Config_t *config);
 bool Config_ParseCommandLine(Config_t *config, int argc, char *argv[]);
 void Config_PrintHelp(const char *progName);
 
-/* E:/Dev/Emulators/ND/nd100x/src/frontend/nd100x/nd100x.c */
+/* /home/ronny/repos/nd100x/src/frontend/nd100x/nd100x.c */
 void handle_sigint(int sig);
 void register_signals(void);
 void dump_stats(void);
@@ -13,5 +13,5 @@ void initialize(void);
 void cleanup(void);
 int main(int argc, char *argv[]);
 
-/* E:/Dev/Emulators/ND/nd100x/src/frontend/nd100x/menu.c */
+/* /home/ronny/repos/nd100x/src/frontend/nd100x/menu.c */
 int show_floppy_menu(void);

--- a/src/frontend/nd100x/screenmenu.c
+++ b/src/frontend/nd100x/screenmenu.c
@@ -108,6 +108,17 @@ static void draw_f12(void)
     fflush(stdout);
 }
 
+static const char *tx_sender_state_name(int state)
+{
+    switch (state) {
+    case 0: return "Stopped";
+    case 1: return "Ready";
+    case 2: return "Sending";
+    case 3: return "Sent";
+    default: return "?";
+    }
+}
+
 static void draw_hdlc_status(void)
 {
     // Home cursor and clear entire screen (repaint in place)
@@ -116,13 +127,6 @@ static void draw_hdlc_status(void)
 
     int count = DeviceManager_GetDeviceCount();
     int found = 0;
-
-    printf("  %-6s  %-10s  %-10s  %-10s  %-10s  %-10s  %-10s  %-10s  %-10s  %s\n",
-           "Dev#", "I/O Addr", "Bytes TX", "Bytes RX",
-           "Frames TX", "Frames RX", "CRC Errs", "RX Frame", "RX Queue", "Connected");
-    printf("  %-6s  %-10s  %-10s  %-10s  %-10s  %-10s  %-10s  %-10s  %-10s  %s\n",
-           "----", "--------", "--------", "--------",
-           "---------", "---------", "--------", "--------", "--------", "---------");
 
     for (int i = 0; i < count; i++) {
         Device *dev = DeviceManager_GetDeviceByIndex(i);
@@ -133,59 +137,102 @@ static void draw_hdlc_status(void)
 
         found++;
 
+        char addrStr[16];
+        snprintf(addrStr, sizeof(addrStr), "%04o-%04o", dev->startAddress, dev->endAddress);
+
+        bool connected = data->modem ? atomic_load(&data->modem->connected) : false;
+
         char txBytesStr[16], rxBytesStr[16];
         format_bytes(data->modem ? data->modem->bytesTx : 0, txBytesStr, sizeof(txBytesStr));
         format_bytes(data->modem ? data->modem->bytesRx : 0, rxBytesStr, sizeof(rxBytesStr));
 
-        bool connected = data->modem ? atomic_load(&data->modem->connected) : false;
+        HDLCRxFrameStatus st;
+        bool hasStatus = HDLC_GetRxFrameStatus(data, &st);
 
-        // RX frame assembly state and queue depth
-        char rxFrameBuf[24];
-        char rxQueueBuf[16];
-        const char *rxFrame = "Idle";
-        const char *rxQueue = "-";
+        // Device header
+        printf("  HDLC #%d  [%s]  Connected: %s\n", data->thumbwheel, addrStr, connected ? "Yes" : "No");
 
-        HDLCRxFrameStatus rxStatus;
-        if (HDLC_GetRxFrameStatus(data, &rxStatus)) {
-            if (!rxStatus.rxDmaEnabled) {
-                rxFrame = "DMA off";
-            } else if (!rxStatus.rxDcbReady) {
-                rxFrame = "No DCB";
-            } else {
-                switch (rxStatus.state) {
-                case 1: // HDLC_STATE_RECEIVING
-                case 2: // HDLC_STATE_ESCAPE
-                    snprintf(rxFrameBuf, sizeof(rxFrameBuf), "Rx %d B", rxStatus.frameLength);
-                    rxFrame = rxFrameBuf;
-                    break;
-                case 3: // HDLC_STATE_ERROR
-                    rxFrame = "Error";
-                    break;
+        // Fixed-width snprintf buffers so columns stay aligned regardless of value length
+        {
+            char c_dma[8], c_bytes[12], c_frames[12], c_ena[16], c_errs[18], c_state[20], c_queue[12];
+            char tmpBuf[24];
+
+            // --- RX line ---
+            snprintf(c_dma, sizeof(c_dma), "%-3s", (hasStatus && st.rxDmaEnabled) ? "On" : "Off");
+            snprintf(c_bytes, sizeof(c_bytes), "%-8s", rxBytesStr);
+            snprintf(c_frames, sizeof(c_frames), "%-8" PRIu64, data->framesRx);
+            snprintf(c_ena, sizeof(c_ena), "RXE=%-6s", (hasStatus && st.rxEnabled) ? "On" : "Off");
+            snprintf(c_errs, sizeof(c_errs), "Errs=%-7" PRIu64, data->framesRxErrors);
+
+            // RX frame assembly state
+            const char *rxState = "Idle";
+            if (hasStatus) {
+                if (!st.rxDmaEnabled) {
+                    rxState = "DMA off";
+                } else if (!st.rxDcbReady) {
+                    rxState = "No DCB";
+                } else {
+                    switch (st.state) {
+                    case 1: case 2:
+                        snprintf(tmpBuf, sizeof(tmpBuf), "Rx %d B", st.frameLength);
+                        rxState = tmpBuf;
+                        break;
+                    case 3:
+                        rxState = "Error";
+                        break;
+                    }
                 }
             }
-            format_bytes(rxStatus.tcpQueueUsed, rxQueueBuf, sizeof(rxQueueBuf));
-            rxQueue = rxQueueBuf;
+            snprintf(c_state, sizeof(c_state), "State=%-10s", rxState);
+
+            if (hasStatus) {
+                format_bytes(st.tcpQueueUsed, c_queue, sizeof(c_queue));
+            } else {
+                snprintf(c_queue, sizeof(c_queue), "-");
+            }
+
+            printf("    RX: DMA=%s  Bytes=%s  Frames=%s  %s  %s  %s  Queue=%s\n",
+                   c_dma, c_bytes, c_frames, c_ena, c_errs, c_state, c_queue);
+
+            // --- TX line ---
+            snprintf(c_dma, sizeof(c_dma), "%-3s", (hasStatus && st.txDmaEnabled) ? "On" : "Off");
+            snprintf(c_bytes, sizeof(c_bytes), "%-8s", txBytesStr);
+            snprintf(c_frames, sizeof(c_frames), "%-8" PRIu64, data->framesTx);
+            snprintf(c_ena, sizeof(c_ena), "TXE=%-6s", (hasStatus && st.txEnabled) ? "On" : "Off");
+            snprintf(c_errs, sizeof(c_errs), "%-12s", "");  // blank to align with RX Errs column
+
+            const char *txState = hasStatus ? tx_sender_state_name(st.txSenderState) : "Stopped";
+            snprintf(c_state, sizeof(c_state), "State=%-10s", txState);
+
+            if (hasStatus) {
+                format_bytes(st.txQueueUsed, c_queue, sizeof(c_queue));
+            } else {
+                snprintf(c_queue, sizeof(c_queue), "-");
+            }
+
+            printf("    TX: DMA=%s  Bytes=%s  Frames=%s  %s  %s  %s  Queue=%s\n",
+                   c_dma, c_bytes, c_frames, c_ena, c_errs, c_state, c_queue);
+
+            // Dropped bytes line (only shown if any drops occurred)
+            uint64_t rxDrop = data->modem ? data->modem->rxDropped : 0;
+            uint64_t txDrop = data->modem ? data->modem->txDropped : 0;
+            if (rxDrop > 0 || txDrop > 0) {
+                char rxDropStr[16], txDropStr[16];
+                format_bytes(rxDrop, rxDropStr, sizeof(rxDropStr));
+                format_bytes(txDrop, txDropStr, sizeof(txDropStr));
+                printf("    ** DROPPED: RX=%s  TX=%s\n", rxDropStr, txDropStr);
+            }
         }
 
-        char addrStr[16];
-        snprintf(addrStr, sizeof(addrStr), "%04o-%04o",
-                 dev->startAddress, dev->endAddress);
-
-        printf("  %-6d  %-10s  %-10s  %-10s  %-10" PRIu64 "  %-10" PRIu64 "  %-10" PRIu64 "  %-10s  %-10s  %s\n",
-               data->thumbwheel,
-               addrStr,
-               txBytesStr, rxBytesStr,
-               data->framesTx, data->framesRx, data->framesRxErrors,
-               rxFrame, rxQueue,
-               connected ? "Yes" : "No");
+        printf("\n");
     }
 
     if (found == 0) {
-        printf("\n  No HDLC devices configured.\n");
+        printf("  No HDLC devices configured.\n");
         printf("  Use --hdlc=N:PORT (server) or --hdlc=N:HOST:PORT (client)\n");
     }
 
-    printf("\n  Refreshes every second. Press ESC to return.\n");
+    printf("  Refreshes every second. Press ESC to return.\n");
     fflush(stdout);
 }
 


### PR DESCRIPTION
## Summary

- **DMA callback chain was completely broken** — DMAControlBlocks/TX/RX callbacks were NULL, all DMA memory access was dead (reads returned 0, writes dropped). Added forwarding wrappers in dmaEngine.c to bridge the callback chain.
- **20-bit DMA addressing** — IOX+17 bank bits were ignored, truncating addresses to 16-bit. SINTRAN's HDLC buffers above 64K were inaccessible.
- **Shadow memory corruption** — `IsAddressShadowMemory` matched 32-bit DMA addresses against 16-bit shadow range (e.g., 0x30FE00 >= 0xF800). DMA read/write now bypasses shadow memory entirely via direct `VolatileMemory` array access, matching C# `SystemBus.ReadMemory16` architecture.
- **DCB key comparison** — `SendAllBuffers` and RX processing compared full `keyValue` (including RCOST flags) against key constants, never matching. Use `DCB_GetKey()` (bits 8-10 only) consistently.
- **COM5025 receiver status** — `WriteByte` to read-only register was a no-op. Use public `SetReceiverStatus()` to update status and trigger RSA pin callback.
- **COM5025 TX output in burst mode** — Idle flags from character-mode transmitter leaked into TCP stream, corrupting byte-stuffed HDLC frames.
- **Outbound TX buffer** — Was NULL (never allocated), no frames could be transmitted.
- **F12 HDLC status display** — RX/TX regions with DMA state, enable bits, queue depth, frame assembly state, and drop counters.
- **Adaptive RX delay** — 50/200/500 ticks based on queue backlog.
- **Buffer sizing** — TCP receive buffer 2MB, modem queue 512KB with retry writes (zero data loss).

## Test plan

- [x] All HDLC unit tests pass (CRC, frame, TCP buffer)
- [x] Build succeeds with no warnings in HDLC code
- [ ] SINTRAN loopback test (C↔C): no MOR crash, frame counts converge
- [ ] SINTRAN cross-test (C↔C#): RXBad=0 on both sides
- [ ] F12 status display shows correct RX/TX state and queue depth